### PR TITLE
[SSK-2011]: Add uniqueBlock aggregation

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -64,6 +64,7 @@ import org.apache.solr.search.facet.SumAgg;
 import org.apache.solr.search.facet.SumsqAgg;
 import org.apache.solr.search.facet.UniqueAgg;
 import org.apache.solr.search.facet.UniqueBlockFieldAgg;
+import org.apache.solr.search.facet.UniqueBlockQueryAgg;
 import org.apache.solr.search.facet.VarianceAgg;
 import org.apache.solr.search.function.CollapseScoreFunction;
 import org.apache.solr.search.function.OrdFieldSource;
@@ -963,6 +964,9 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
     addParser("agg_uniqueBlock", new ValueSourceParser() {
       @Override
       public ValueSource parse(FunctionQParser fp) throws SyntaxError {
+        if (fp.sp.peek() == QueryParsing.LOCALPARAM_START.charAt(0) ) {
+          return new UniqueBlockQueryAgg(fp.parseNestedQuery());
+        }
         return new UniqueBlockFieldAgg(fp.parseArg());
       }
     });

--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -63,6 +63,7 @@ import org.apache.solr.search.facet.StddevAgg;
 import org.apache.solr.search.facet.SumAgg;
 import org.apache.solr.search.facet.SumsqAgg;
 import org.apache.solr.search.facet.UniqueAgg;
+import org.apache.solr.search.facet.UniqueBlockFieldAgg;
 import org.apache.solr.search.facet.VarianceAgg;
 import org.apache.solr.search.function.CollapseScoreFunction;
 import org.apache.solr.search.function.OrdFieldSource;
@@ -956,6 +957,13 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
       @Override
       public ValueSource parse(FunctionQParser fp) throws SyntaxError {
         return new UniqueAgg(fp.parseArg());
+      }
+    });
+
+    addParser("agg_uniqueBlock", new ValueSourceParser() {
+      @Override
+      public ValueSource parse(FunctionQParser fp) throws SyntaxError {
+        return new UniqueBlockFieldAgg(fp.parseArg());
       }
     });
 

--- a/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockAgg.java
@@ -23,12 +23,9 @@ import java.util.Arrays;
 import org.apache.lucene.index.MultiDocValues;
 import org.apache.solr.schema.SchemaField;
 
-/**
- * @author munendrasn
- */
 public abstract class UniqueBlockAgg extends UniqueAgg {
 
-  private final static String uniqueBlock = "uniqueBlock";
+  private static final String uniqueBlock = "uniqueBlock";
 
   protected static class UniqueBlockSlotAcc extends UniqueSinglevaluedSlotAcc {
 

--- a/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockAgg.java
@@ -18,6 +18,10 @@
 package org.apache.solr.search.facet;
 
 import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.lucene.index.MultiDocValues;
+import org.apache.solr.schema.SchemaField;
 
 /**
  * @author munendrasn
@@ -25,6 +29,59 @@ import java.io.IOException;
 public abstract class UniqueBlockAgg extends UniqueAgg {
 
   private final static String uniqueBlock = "uniqueBlock";
+
+  protected static class UniqueBlockSlotAcc extends UniqueSinglevaluedSlotAcc {
+
+    protected int[] lastSeenValuesPerSlot;
+
+    public UniqueBlockSlotAcc(FacetContext fcontext, SchemaField field, int numSlots) throws IOException {
+      super(fcontext, field, 0, null);
+      counts = new int[numSlots];
+      lastSeenValuesPerSlot = new int[numSlots];
+      Arrays.fill(lastSeenValuesPerSlot, Integer.MIN_VALUE);
+    }
+
+    @Override
+    protected void collectOrdToSlot(int slotNum, int ord) {
+      if (lastSeenValuesPerSlot[slotNum]!=ord) {
+        counts[slotNum]+=1;
+        lastSeenValuesPerSlot[slotNum] = ord;
+      }
+    }
+
+    @Override
+    public void reset() throws IOException {
+      // copying this to so that super.reset() is not called
+      // as it sets counts to null
+      topLevel = FieldUtil.getSortedDocValues(fcontext.qcontext, field, null);
+      nTerms = topLevel.getValueCount();
+      if (topLevel instanceof MultiDocValues.MultiSortedDocValues) {
+        ordMap = ((MultiDocValues.MultiSortedDocValues)topLevel).mapping;
+        subDvs = ((MultiDocValues.MultiSortedDocValues)topLevel).values;
+      } else {
+        ordMap = null;
+        subDvs = null;
+      }
+      Arrays.fill(counts, 0);
+      Arrays.fill(lastSeenValuesPerSlot, Integer.MIN_VALUE);
+    }
+
+    @Override
+    public void calcCounts() {
+      // noop already done
+    }
+
+    @Override
+    public Object getValue(int slot) throws IOException {
+      return counts[slot];
+    }
+
+    @Override
+    public void resize(Resizer resizer) {
+      lastSeenValuesPerSlot = resizer.resize(lastSeenValuesPerSlot, Integer.MIN_VALUE);
+      super.resize(resizer);
+    }
+  }
 
   public UniqueBlockAgg(String field) {
     super(field);

--- a/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockAgg.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+
+/**
+ * @author munendrasn
+ */
+public abstract class UniqueBlockAgg extends UniqueAgg {
+
+  private final static String uniqueBlock = "uniqueBlock";
+
+  public UniqueBlockAgg(String field) {
+    super(field);
+    name = uniqueBlock;
+  }
+
+  @Override
+  public abstract SlotAcc createSlotAcc(FacetContext fcontext, int numDocs, int numSlots) throws IOException;
+
+  @Override
+  public FacetMerger createFacetMerger(Object prototype) {
+    return new FacetLongMerger() ;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockFieldAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockFieldAgg.java
@@ -18,68 +18,13 @@
 package org.apache.solr.search.facet;
 
 import java.io.IOException;
-import java.util.Arrays;
 
-import org.apache.lucene.index.MultiDocValues;
 import org.apache.solr.schema.SchemaField;
 
 /**
  * @author munendrasn
  */
 public class UniqueBlockFieldAgg extends UniqueBlockAgg {
-
-  protected static class UniqueBlockSlotAcc extends UniqueSinglevaluedSlotAcc {
-
-    protected int[] lastSeenValuesPerSlot;
-
-    public UniqueBlockSlotAcc(FacetContext fcontext, SchemaField field, int numSlots) throws IOException {
-      super(fcontext, field, 0, null);
-      counts = new int[numSlots];
-      lastSeenValuesPerSlot = new int[numSlots];
-      Arrays.fill(lastSeenValuesPerSlot, Integer.MIN_VALUE);
-    }
-
-    @Override
-    protected void collectOrdToSlot(int slotNum, int ord) {
-      if (lastSeenValuesPerSlot[slotNum]!=ord) {
-        counts[slotNum]+=1;
-        lastSeenValuesPerSlot[slotNum] = ord;
-      }
-    }
-
-    @Override
-    public void reset() throws IOException {
-      // copying this to so that super.reset() is not called
-      // as it sets counts to null
-      topLevel = FieldUtil.getSortedDocValues(fcontext.qcontext, field, null);
-      nTerms = topLevel.getValueCount();
-      if (topLevel instanceof MultiDocValues.MultiSortedDocValues) {
-        ordMap = ((MultiDocValues.MultiSortedDocValues)topLevel).mapping;
-        subDvs = ((MultiDocValues.MultiSortedDocValues)topLevel).values;
-      } else {
-        ordMap = null;
-        subDvs = null;
-      }
-      Arrays.fill(counts, 0);
-      Arrays.fill(lastSeenValuesPerSlot, Integer.MIN_VALUE);
-    }
-
-    @Override
-    public void calcCounts() {
-      // noop already done
-    }
-
-    @Override
-    public Object getValue(int slot) throws IOException {
-      return counts[slot];
-    }
-
-    @Override
-    public void resize(Resizer resizer) {
-      lastSeenValuesPerSlot = resizer.resize(lastSeenValuesPerSlot, Integer.MIN_VALUE);
-      super.resize(resizer);
-    }
-  }
 
   public UniqueBlockFieldAgg(String field) {
     super(field);

--- a/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockFieldAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockFieldAgg.java
@@ -21,9 +21,6 @@ import java.io.IOException;
 
 import org.apache.solr.schema.SchemaField;
 
-/**
- * @author munendrasn
- */
 public class UniqueBlockFieldAgg extends UniqueBlockAgg {
 
   public UniqueBlockFieldAgg(String field) {
@@ -42,7 +39,6 @@ public class UniqueBlockFieldAgg extends UniqueBlockAgg {
         throw new IllegalArgumentException(name+"("+fieldName+
             ") not yet support numbers " + sf);
       } else {
-        // replace this
         return new UniqueBlockSlotAcc(fcontext, sf, numSlots);
       }
     }

--- a/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockFieldAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockFieldAgg.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.lucene.index.MultiDocValues;
+import org.apache.solr.schema.SchemaField;
+
+/**
+ * @author munendrasn
+ */
+public class UniqueBlockFieldAgg extends UniqueBlockAgg {
+
+  protected static class UniqueBlockSlotAcc extends UniqueSinglevaluedSlotAcc {
+
+    protected int[] lastSeenValuesPerSlot;
+
+    public UniqueBlockSlotAcc(FacetContext fcontext, SchemaField field, int numSlots) throws IOException {
+      super(fcontext, field, 0, null);
+      counts = new int[numSlots];
+      lastSeenValuesPerSlot = new int[numSlots];
+      Arrays.fill(lastSeenValuesPerSlot, Integer.MIN_VALUE);
+    }
+
+    @Override
+    protected void collectOrdToSlot(int slotNum, int ord) {
+      if (lastSeenValuesPerSlot[slotNum]!=ord) {
+        counts[slotNum]+=1;
+        lastSeenValuesPerSlot[slotNum] = ord;
+      }
+    }
+
+    @Override
+    public void reset() throws IOException {
+      // copying this to so that super.reset() is not called
+      // as it sets counts to null
+      topLevel = FieldUtil.getSortedDocValues(fcontext.qcontext, field, null);
+      nTerms = topLevel.getValueCount();
+      if (topLevel instanceof MultiDocValues.MultiSortedDocValues) {
+        ordMap = ((MultiDocValues.MultiSortedDocValues)topLevel).mapping;
+        subDvs = ((MultiDocValues.MultiSortedDocValues)topLevel).values;
+      } else {
+        ordMap = null;
+        subDvs = null;
+      }
+      Arrays.fill(counts, 0);
+      Arrays.fill(lastSeenValuesPerSlot, Integer.MIN_VALUE);
+    }
+
+    @Override
+    public void calcCounts() {
+      // noop already done
+    }
+
+    @Override
+    public Object getValue(int slot) throws IOException {
+      return counts[slot];
+    }
+
+    @Override
+    public void resize(Resizer resizer) {
+      lastSeenValuesPerSlot = resizer.resize(lastSeenValuesPerSlot, Integer.MIN_VALUE);
+      super.resize(resizer);
+    }
+  }
+
+  public UniqueBlockFieldAgg(String field) {
+    super(field);
+  }
+
+  @Override
+  public SlotAcc createSlotAcc(FacetContext fcontext, int numDocs, int numSlots) throws IOException {
+    final String fieldName = getArg();
+    SchemaField sf = fcontext.qcontext.searcher().getSchema().getField(fieldName);
+    if (sf.multiValued() || sf.getType().multiValuedFieldCache()) {
+      throw new IllegalArgumentException(name+"("+fieldName+
+          ") doesn't allow multivalued fields, got " + sf);
+    } else {
+      if (sf.getType().getNumberType() != null) {
+        throw new IllegalArgumentException(name+"("+fieldName+
+            ") not yet support numbers " + sf);
+      } else {
+        // replace this
+        return new UniqueBlockSlotAcc(fcontext, sf, numSlots);
+      }
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockQueryAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UniqueBlockQueryAgg.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BitSet;
+
+import static org.apache.solr.search.join.BlockJoinParentQParser.getCachedFilter;
+
+public class UniqueBlockQueryAgg extends UniqueBlockAgg {
+
+  private static final class UniqueBlockQuerySlotAcc extends UniqueBlockSlotAcc {
+
+    private Query query;
+    private BitSet parentBitSet;
+
+    public UniqueBlockQuerySlotAcc(FacetContext fcontext, Query query, int numSlots) throws IOException {
+      super(fcontext, null, numSlots);
+      this.query = query;
+    }
+
+    @Override
+    public void setNextReader(LeafReaderContext readerContext) throws IOException {
+      parentBitSet = getCachedFilter(fcontext.req, query).getFilter().getBitSet(readerContext);
+    }
+
+    @Override
+    public void reset() throws IOException {
+      Arrays.fill(counts, 0);
+      Arrays.fill(lastSeenValuesPerSlot, Integer.MIN_VALUE);
+    }
+
+    @Override
+    public void collect(int doc, int slotNum) {
+      if (parentBitSet != null) {
+        int ord = parentBitSet.nextSetBit(doc);
+        if (ord != DocIdSetIterator.NO_MORE_DOCS) {
+          collectOrdToSlot(slotNum, ord);
+        }
+      }
+    }
+  }
+
+  private final Query query;
+
+  public UniqueBlockQueryAgg(Query query) {
+    super(null);
+    this.query = query;
+    arg = query.toString();
+  }
+
+  @Override
+  public SlotAcc createSlotAcc(FacetContext fcontext, int numDocs, int numSlots) throws IOException {
+    return new UniqueBlockQuerySlotAcc(fcontext, query, numSlots);
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/UniqueSinglevaluedSlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UniqueSinglevaluedSlotAcc.java
@@ -26,7 +26,6 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.LongValues;
 import org.apache.solr.schema.SchemaField;
-import org.apache.solr.search.SolrIndexSearcher;
 
 class UniqueSinglevaluedSlotAcc extends UniqueSlotAcc {
   SortedDocValues topLevel;
@@ -43,7 +42,6 @@ class UniqueSinglevaluedSlotAcc extends UniqueSlotAcc {
   @Override
   public void reset() throws IOException {
     super.reset();
-    SolrIndexSearcher searcher = fcontext.qcontext.searcher();
     topLevel = FieldUtil.getSortedDocValues(fcontext.qcontext, field, null);
     nTerms = topLevel.getValueCount();
     if (topLevel instanceof MultiDocValues.MultiSortedDocValues) {
@@ -81,6 +79,10 @@ class UniqueSinglevaluedSlotAcc extends UniqueSlotAcc {
     if (segOrd < 0) return;  // -1 means missing
     int ord = toGlobal==null ? segOrd : (int)toGlobal.get(segOrd);
 
+    collectOrdToSlot(slotNum, ord);
+  }
+
+  protected void collectOrdToSlot(int slotNum, int ord) {
     FixedBitSet bits = arr[slotNum];
     if (bits == null) {
       bits = new FixedBitSet(nTerms);

--- a/solr/core/src/java/org/apache/solr/search/facet/UniqueSlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UniqueSlotAcc.java
@@ -155,5 +155,8 @@ abstract class UniqueSlotAcc extends SlotAcc {
   @Override
   public void resize(Resizer resizer) {
     arr = resizer.resize(arr, null);
+    if (counts != null) {
+      counts = resizer.resize(counts, 0);
+    }
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/join/BlockJoinParentQParser.java
@@ -79,7 +79,7 @@ public class BlockJoinParentQParser extends QParser {
     return getCachedFilter(req, parentList);
   }
 
-  static BitDocIdSetFilterWrapper getCachedFilter(final SolrQueryRequest request, Query parentList) {
+  public static BitDocIdSetFilterWrapper getCachedFilter(final SolrQueryRequest request, Query parentList) {
     SolrCache parentCache = request.getSearcher().getCache(CACHE_NAME);
     // lazily retrieve from solr cache
     Filter filter = null;
@@ -117,7 +117,7 @@ public class BlockJoinParentQParser extends QParser {
   }
 
   // We need this wrapper since BitDocIdSetFilter does not extend Filter
-  static class BitDocIdSetFilterWrapper extends Filter {
+  public static class BitDocIdSetFilterWrapper extends Filter {
 
     final BitSetProducer filter;
 
@@ -132,6 +132,10 @@ public class BlockJoinParentQParser extends QParser {
         return null;
       }
       return BitsFilteredDocIdSet.wrap(new BitDocIdSet(set), acceptDocs);
+    }
+
+    public BitSetProducer getFilter() {
+      return filter;
     }
 
     @Override

--- a/solr/core/src/test-files/solr/collection1/conf/schema-blockjoinfacetcomponent.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema-blockjoinfacetcomponent.xml
@@ -22,9 +22,9 @@
   <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
   <fieldtype name="string" class="solr.StrField" sortMissingLast="true"/>
 
-  <field name="id" type="int" indexed="true" stored="true" multiValued="false" required="false"/>
+  <field name="id" type="string" indexed="true" stored="true" multiValued="false" required="false"/>
   <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
-  <field name="_root_" type="int" indexed="true" stored="true" multiValued="false" required="false"/>
+  <field name="_root_" type="string" indexed="true" stored="true" multiValued="false" required="false"/>
 
   <field name="name" type="string" indexed="true" stored="true"/>
   <dynamicField name="*_s" type="string" indexed="true" stored="true" multiValued="false"/>

--- a/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
+++ b/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
@@ -1097,6 +1097,7 @@ public class QueryEqualityTest extends SolrTestCaseJ4 {
     assertFuncEquals("agg_sum(foo_i)", "agg_sum(foo_i)");
     assertFuncEquals("agg_count()", "agg_count()");
     assertFuncEquals("agg_unique(foo_i)", "agg_unique(foo_i)");
+    assertFuncEquals("agg_uniqueBlock(foo_i)", "agg_uniqueBlock(foo_i)");
     assertFuncEquals("agg_hll(foo_i)", "agg_hll(foo_i)");
     assertFuncEquals("agg_sumsq(foo_i)", "agg_sumsq(foo_i)");
     assertFuncEquals("agg_percentile(foo_i,50)", "agg_percentile(foo_i,50)");

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -16,8 +16,6 @@
  */
 package org.apache.solr.search.facet;
 
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-import com.tdunning.math.stats.AVLTreeDigest;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,17 +26,19 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 
-import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.common.SolrException;
-import org.apache.solr.util.hll.HLL;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.tdunning.math.stats.AVLTreeDigest;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.solr.JSONTestUtil;
 import org.apache.solr.SolrTestCaseHS;
-import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.SolrTestCaseJ4.SuppressPointFields;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.macro.MacroExpander;
+import org.apache.solr.util.hll.HLL;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1561,6 +1561,79 @@ public class TestJsonFacets extends SolrTestCaseHS {
     );
   }
 
+  /**
+   * An explicit test for unique*(_root_) across all methods
+   */
+  public void testUniquesForMethod() throws Exception {
+    final Client client = Client.localClient();
+
+    final SolrParams p = params("rows","0");
+
+    client.deleteByQuery("*:*", null);
+
+    SolrInputDocument parent;
+    parent = sdoc("id", "1", "type_s","book", "book_s","A", "v_t","q");
+    client.add(parent, null);
+
+    parent = sdoc("id", "2", "type_s","book", "book_s","B", "v_t","q w");
+    parent.addChildDocument( sdoc("id","2.1", "type_s","page", "page_s","a", "v_t","x y z")  );
+    parent.addChildDocument( sdoc("id","2.2", "type_s","page", "page_s","a", "v_t","x1   z")  );
+    parent.addChildDocument( sdoc("id","2.3", "type_s","page", "page_s","a", "v_t","x2   z")  );
+    parent.addChildDocument( sdoc("id","2.4", "type_s","page", "page_s","b", "v_t","x y  ") );
+    parent.addChildDocument( sdoc("id","2.5", "type_s","page", "page_s","c", "v_t","  y z" )  );
+    parent.addChildDocument( sdoc("id","2.6", "type_s","page", "page_s","c", "v_t","    z" )  );
+    client.add(parent, null);
+
+    parent = sdoc("id", "3", "type_s","book", "book_s","C", "v_t","q w e");
+    parent.addChildDocument( sdoc("id","3.1", "type_s","page", "page_s","b", "v_t","x y  ") );
+    parent.addChildDocument( sdoc("id","3.2", "type_s","page", "page_s","d", "v_t","x    ")  );
+    parent.addChildDocument( sdoc("id","3.3", "type_s","page", "page_s","e", "v_t","  y  ")  );
+    parent.addChildDocument( sdoc("id","3.4", "type_s","page", "page_s","f", "v_t","    z")  );
+    client.add(parent, null);
+
+    parent = sdoc("id", "4", "type_s","book", "book_s","D", "v_t","e");
+    client.add(parent, null);
+
+    client.commit();
+
+    client.testJQ(params(p, "q", "type_s:page"
+        , "json.facet", "{" +
+            "  types: {" +
+            "    type:terms," +
+            "    field:type_s," +
+            "    limit:-1," +
+            "    facet: {" +
+            "           in_books: \"unique(_root_)\"," +
+            "           via_field:\"uniqueBlock(_root_)\","+
+            "           via_query:\"uniqueBlock({!v=type_s:book})\" }"+
+            "  }," +
+            "  pages: {" +
+            "    type:terms," +
+            "    field:page_s," +
+            "    limit:-1," +
+            "    facet: {" +
+            "           in_books: \"unique(_root_)\"," +
+            "           via_field:\"uniqueBlock(_root_)\","+
+            "           via_query:\"uniqueBlock({!v=type_s:book})\" }"+
+            "  }" +
+            "}" )
+
+        , "response=={numFound:10,start:0,docs:[]}"
+        , "facets=={ count:10," +
+            "types:{" +
+            "    buckets:[ {val:page, count:10, in_books:2, via_field:2, via_query:2 } ]}," +
+            "pages:{" +
+            "    buckets:[ " +
+            "     {val:a, count:3, in_books:1, via_field:1, via_query:1}," +
+            "     {val:b, count:2, in_books:2, via_field:2, via_query:2}," +
+            "     {val:c, count:2, in_books:1, via_field:1, via_query:1}," +
+            "     {val:d, count:1, in_books:1, via_field:1, via_query:1}," +
+            "     {val:e, count:1, in_books:1, via_field:1, via_query:1}," +
+            "     {val:f, count:1, in_books:1, via_field:1, via_query:1}" +
+            "    ]}" +
+            "}"
+    );
+  }
 
 
   @Test

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetsWithNestedObjects.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacetsWithNestedObjects.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import org.apache.solr.SolrTestCaseHS;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestJsonFacetsWithNestedObjects extends SolrTestCaseHS{
+
+  @BeforeClass
+  public static void beforeTests() throws Exception {
+    initCore("solrconfig-tlog.xml","schema_latest.xml");
+    indexBooksAndReviews();
+  }
+
+  private static void indexBooksAndReviews() throws Exception {
+    final Client client = Client.localClient();
+    client.deleteByQuery("*:*", null);
+
+    SolrInputDocument book1 = sdoc(
+        "id",         "book1",
+        "type_s",     "book",
+        "title_t",    "The Way of Kings",
+        "author_s",   "Brandon Sanderson",
+        "cat_s",      "fantasy",
+        "pubyear_i",  "2010",
+        "publisher_s","Tor");
+
+    book1.addChildDocument(
+        sdoc(
+            "id", "book1_c1",
+            "type_s", "review",
+            "review_dt", "2015-01-03T14:30:00Z",
+            "stars_i", "5",
+            "author_s", "yonik",
+            "comment_t", "A great start to what looks like an epic series!"));
+
+    book1.addChildDocument(
+        sdoc(
+            "id", "book1_c2",
+            "type_s", "review",
+            "review_dt", "2014-03-15T12:00:00Z",
+            "stars_i", "3",
+            "author_s", "dan",
+            "comment_t", "This book was too long."));
+    client.add(book1, null);
+
+    SolrInputDocument book2 = sdoc(
+        "id",         "book2",
+        "type_s",     "book",
+        "title_t",    "Snow Crash",
+        "author_s",   "Neal Stephenson",
+        "cat_s",      "sci-fi",
+        "pubyear_i",  "1992",
+        "publisher_s","Bantam");
+
+    book2.addChildDocument(
+        sdoc(
+            "id", "book2_c1",
+            "type_s", "review",
+            "review_dt", "2015-01-03T14:30:00Z",
+            "stars_i", "5",
+            "author_s", "yonik",
+            "comment_t", "Ahead of its time... I wonder if it helped inspire The Matrix?"));
+
+    book2.addChildDocument(
+        sdoc(
+            "id", "book2_c2",
+            "type_s", "review",
+            "review_dt", "2015-04-10T9:00:00Z",
+            "stars_i", "2",
+            "author_s", "dan",
+            "comment_t", "A pizza boy for the Mafia franchise? Really?"));
+
+    book2.addChildDocument(
+        sdoc(
+            "id", "book2_c3",
+            "type_s", "review",
+            "review_dt", "2015-06-02T00:00:00Z",
+            "stars_i", "4",
+            "author_s", "mary",
+            "comment_t", "Neal is so creative and detailed! Loved the metaverse!"));
+
+    client.add(book2, null);
+    client.commit();
+  }
+
+  /**
+   * Example from http://yonik.com/solr-nested-objects/
+   * The main query gives us a document list of reviews by author_s:yonik
+   * If we want to facet on the book genre (cat_s field) then we need to
+   * switch the domain from the children (type_s:reviews) to the parents (type_s:books).
+   *
+   * And we get a facet over the books which yonik reviewed
+   *
+   * Note that regardless of which direction we are mapping
+   * (parents to children or children to parents),
+   * we provide a query that defines the complete set of parents in the index.
+   * In these examples, the parent filter is “type_s:book”.
+   */
+  @Test
+  public void testFacetingOnParents() throws Exception {
+    final Client client = Client.localClient();
+    ModifiableSolrParams p = params("rows","10");
+    client.testJQ(params(p, "q", "author_s:yonik", "fl", "id", "fl" , "comment_t"
+        , "json.facet", "{" +
+            "  genres: {" +
+            "    type:terms," +
+            "    field:cat_s," +
+            "    domain: { blockParent : \"type_s:book\" }" +
+            "  }" +
+            "}"
+        )
+        , "response=={numFound:2,start:0,docs:[" +
+            "      {id:book1_c1," +
+            "        comment_t:\"A great start to what looks like an epic series!\"}," +
+            "      {id:book2_c1," +
+            "        comment_t:\"Ahead of its time... I wonder if it helped inspire The Matrix?\"}]}"
+        , "facets=={ count:2," +
+            "genres:{buckets:[ {val:fantasy, count:1}," +
+            "                  {val:sci-fi,  count:1}]}}"
+    );
+  }
+
+  /**
+   * Example from http://yonik.com/solr-nested-objects/
+   * Now lets say we’re displaying the top sci-fi and fantasy books,
+   * and we want to find out who reviews the most books out of our selection.
+   * Since our root implicit facet bucket (formed by the query and filters)
+   * consists of parent documents (books),
+   * we need to switch the facet domain to the children for the author facet.
+   *
+   * Note that regardless of which direction we are mapping
+   * (parents to children or children to parents),
+   * we provide a query that defines the complete set of parents in the index.
+   * In these examples, the parent filter is “type_s:book”.
+   */
+  @Test
+  public void testFacetingOnChildren() throws Exception {
+    final Client client = Client.localClient();
+    ModifiableSolrParams p = params("rows","10");
+    client.testJQ(params(p, "q", "cat_s:(sci-fi OR fantasy)", "fl", "id", "fl" , "title_t"
+        , "json.facet", "{" +
+            "  top_reviewers: {" +
+            "    type:terms," +
+            "    field:author_s," +
+            "    domain: { blockChildren : \"type_s:book\" }" +
+            "  }" +
+            "}"
+        )
+        , "response=={numFound:2,start:0,docs:[" +
+            "      {id:book1," +
+            "        title_t:\"The Way of Kings\"}," +
+            "      {id:book2," +
+            "        title_t:\"Snow Crash\"}]}"
+        , "facets=={ count:2," +
+            "top_reviewers:{buckets:[ {val:dan,     count:2}," +
+            "                         {val:yonik,   count:2}," +
+            "                         {val:mary,    count:1} ]}}"
+    );
+  }
+
+
+  /**
+   * Explicit filter exclusions for rolled up child facets
+   */
+  @Test
+  public void testExplicitFilterExclusions() throws Exception {
+    final Client client = Client.localClient();
+    ModifiableSolrParams p = params("rows","10");
+    client.testJQ(params(p, "q", "{!parent which=type_s:book}comment_t:* %2Bauthor_s:yonik %2Bstars_i:(5 3)"
+        , "fl", "id", "fl" , "title_t"
+        , "json.facet", "{" +
+            "  comments_for_author: {" +
+            "    type:query," +
+            //note: author filter is excluded
+            "    q:\"comment_t:* +stars_i:(5 3)\"," +
+            "    domain: { blockChildren : \"type_s:book\" }," +
+            "    facet:{" +
+            "      authors:{" +
+            "        type:terms," +
+            "        field:author_s," +
+            "        facet: {" +
+            "           in_books: \"unique(_root_)\" }}}}," +
+            "  comments_for_stars: {" +
+            "    type:query," +
+            //note: stars_i filter is excluded
+            "    q:\"comment_t:* +author_s:yonik\"," +
+            "    domain: { blockChildren : \"type_s:book\" }," +
+            "    facet:{" +
+            "      stars:{" +
+            "        type:terms," +
+            "        field:stars_i," +
+            "        facet: {" +
+            "           in_books: \"unique(_root_)\" }}}}}" )
+
+        , "response=={numFound:2,start:0,docs:[" +
+            "      {id:book1," +
+            "        title_t:\"The Way of Kings\"}," +
+            "      {id:book2," +
+            "        title_t:\"Snow Crash\"}]}"
+        , "facets=={ count:2," +
+            "comments_for_author:{" +
+            "  count:3," +
+            "  authors:{" +
+            "    buckets:[ {val:yonik,  count:2, in_books:2}," +
+            "              {val:dan,    count:1, in_books:1} ]}}," +
+            "comments_for_stars:{" +
+            "  count:2," +
+            "  stars:{" +
+            "    buckets:[ {val:5, count:2, in_books:2} ]}}}"
+    );
+  }
+
+  @Test
+  public void testUniqueBlock() throws Exception {
+    final Client client = Client.localClient();
+    ModifiableSolrParams p = params("rows","0");
+    client.testJQ(params(p, "q", "{!parent tag=top which=type_s:book v=$childquery}"
+        , "childquery", "comment_t:*"
+        , "fl", "id", "fl" , "title_t"
+        , "json.facet", "{" +
+            "  types: {" +
+            "    domain: { blockChildren:\"type_s:book\"" +
+            "            }," +
+            "    type:terms," +
+            "    field:type_s,"
+            + "  limit:-1," +
+            "    facet: {" +
+            "           in_old__books: \"unique(_root_)\", " +
+            "           in_books: \"uniqueBlock(_root_)\" }" +
+            "  }" +
+            "}" )
+
+        , "response=={numFound:2,start:0,docs:[]}"
+        , "facets=={ count:2," +
+            "types:{" +
+            "    buckets:[ {val:review,    count:5, in_old__books:2, in_books:2} ]}" +
+            "}"
+    );
+  }
+
+}


### PR DESCRIPTION
* This backports both `uniqueBlock(_root_)` and `uniqueBlock({!v=parent_unbxd:true})`