### PR TITLE
fix: build changes pushing maven artifacts to repository

### DIFF
--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -205,6 +205,7 @@
   <property name="m2.repository.private.key" value="${user.home}/.ssh/id_dsa"/>
   <property name="m2.repository.id" value="local"/>
   <property name="m2.credentials.prompt" value="true"/>
+  <property name="maven.repository.id" value="remote"/>
 
   <property name="tests.workDir" location="${build.dir}/test"/>
   <property name="junit.output.dir" location="${build.dir}/test"/>
@@ -590,13 +591,13 @@
     <attribute name="pom.xml"/>
     <attribute name="jar.file" default="${dist.jar.dir.prefix}-${version}/${dist.jar.dir.suffix}/${final.name}.jar"/>
     <sequential>
-      <artifact:install-provider artifactId="wagon-ssh" version="1.0-beta-7"/>
+      <artifact:install-provider artifactId="wagon-ssh" version="1.0-beta-7">
+        <remoteRepository id="${maven.repository.id}" url="${ivy_bootstrap_url1}" />
+      </artifact:install-provider>
       <parent-poms/>
-      <artifact:pom id="maven.project" file="@{pom.xml}"/>
-      <artifact:install file="@{jar.file}">
-        <artifact-attachments/>
-        <pom refid="maven.project"/>
-      </artifact:install>
+      <artifact:pom id="maven.project" file="@{pom.xml}">
+        <remoteRepository id="${maven.repository.id}" url="${ivy_bootstrap_url1}" />
+      </artifact:pom>
       <artifact:deploy file="@{jar.file}">
         <artifact-attachments/>
         <remoteRepository id="${m2.repository.id}" url="${m2.repository.url}">
@@ -604,6 +605,10 @@
         </remoteRepository>
         <pom refid="maven.project"/>
       </artifact:deploy>
+      <artifact:install file="@{jar.file}">
+        <artifact-attachments/>
+        <pom refid="maven.project"/>
+      </artifact:install>
     </sequential>
   </macrodef>
   


### PR DESCRIPTION
* LUCENE-9170: use https instead of http
* SOLR-11181: handle failure in pushing artifacts to repository.
  Only required changes for our usecase are backported