### PR TITLE
Increase the request header size

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION}}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
      
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     if: github.repository == 'unbxd/lucene-solr'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: "us-east-1"
      
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     if: github.repository == 'unbxd/lucene-solr'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/solr/server/etc/jetty.xml
+++ b/solr/server/etc/jetty.xml
@@ -68,7 +68,7 @@
     <Set name="securePort"><Property name="solr.jetty.secure.port" default="8443" /></Set>
     <Set name="outputBufferSize"><Property name="solr.jetty.output.buffer.size" default="32768" /></Set>
     <Set name="outputAggregationSize"><Property name="solr.jetty.output.aggregation.size" default="8192" /></Set>
-    <Set name="requestHeaderSize"><Property name="solr.jetty.request.header.size" default="8192" /></Set>
+    <Set name="requestHeaderSize"><Property name="solr.jetty.request.header.size" default="40960" /></Set>
     <Set name="responseHeaderSize"><Property name="solr.jetty.response.header.size" default="8192" /></Set>
     <Set name="sendServerVersion"><Property name="solr.jetty.send.server.version" default="false" /></Set>
     <Set name="sendDateHeader"><Property name="solr.jetty.send.date.header" default="false" /></Set>


### PR DESCRIPTION
for personalization when large queries consisting of 1000 alt.ids are sent it doesnt process, shows o.e.j.h.HttpParser URI is too large >8192