### PR TITLE
[PLAT-713]: change access modifier to public for necessary classes

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/facet/CountSlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/CountSlotAcc.java
@@ -1,0 +1,11 @@
+package org.apache.solr.search.facet;
+
+public abstract class CountSlotAcc extends SlotAcc {
+    public CountSlotAcc(FacetContext fcontext) {
+        super(fcontext);
+    }
+
+    public abstract void incrementCount(int slot, int count);
+
+    public abstract int getCount(int slot);
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/CountSlotArrAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/CountSlotArrAcc.java
@@ -1,0 +1,52 @@
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class CountSlotArrAcc extends CountSlotAcc {
+    int[] result;
+
+    public CountSlotArrAcc(FacetContext fcontext, int numSlots) {
+        super(fcontext);
+        result = new int[numSlots];
+    }
+
+    @Override
+    public void collect(int doc, int slotNum) { // TODO: count arrays can use fewer bytes based on the number of docs in
+        // the base set (that's the upper bound for single valued) - look at ttf?
+        result[slotNum]++;
+    }
+
+    @Override
+    public int compare(int slotA, int slotB) {
+        return Integer.compare(result[slotA], result[slotB]);
+    }
+
+    @Override
+    public Object getValue(int slotNum) throws IOException {
+        return result[slotNum];
+    }
+
+    public void incrementCount(int slot, int count) {
+        result[slot] += count;
+    }
+
+    public int getCount(int slot) {
+        return result[slot];
+    }
+
+    // internal and expert
+    int[] getCountArray() {
+        return result;
+    }
+
+    @Override
+    public void reset() {
+        Arrays.fill(result, 0);
+    }
+
+    @Override
+    public void resize(Resizer resizer) {
+        resizer.resize(result, 0);
+    }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetComponentState.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetComponentState.java
@@ -1,0 +1,22 @@
+package org.apache.solr.search.facet;
+
+import org.apache.solr.handler.component.ResponseBuilder;
+
+import java.util.Map;
+
+// TODO: perhaps factor out some sort of root/parent facet object that doesn't depend
+// on stuff like ResponseBuilder, but contains request parameters,
+// root filter lists (for filter exclusions), etc?
+public class FacetComponentState {
+    ResponseBuilder rb;
+    Map<String, Object> facetCommands;
+    FacetRequest facetRequest;
+    boolean isShard;
+    Map<String, Object> facetInfo; // _facet_ param: contains out-of-band facet info, mainly for refinement requests
+
+    //
+    // Only used for distributed search
+    //
+    FacetMerger merger;
+    FacetMerger.Context mcontext;
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetContext.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetContext.java
@@ -1,0 +1,57 @@
+package org.apache.solr.search.facet;
+
+import org.apache.lucene.search.Query;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.search.DocSet;
+import org.apache.solr.search.QueryContext;
+import org.apache.solr.search.SolrIndexSearcher;
+
+import java.util.Map;
+
+public class FacetContext {
+    // Context info for actually executing a local facet command
+    public static final int IS_SHARD = 0x01;
+    public static final int IS_REFINEMENT = 0x02;
+    public static final int SKIP_FACET = 0x04;  // refinement: skip calculating this immediate facet, but proceed to specific sub-facets based on facetInfo
+
+    public Map<String, Object> facetInfo; // refinement info for this node
+    public QueryContext qcontext;
+    public SolrQueryRequest req;  // TODO: replace with params?
+    public SolrIndexSearcher searcher;
+    public Query filter;  // TODO: keep track of as a DocSet or as a Query?
+    public DocSet base;
+    public FacetContext parent;
+    public int flags;
+    FacetDebugInfo debugInfo;
+
+    public void setDebugInfo(FacetDebugInfo debugInfo) {
+        this.debugInfo = debugInfo;
+    }
+
+    public FacetDebugInfo getDebugInfo() {
+        return debugInfo;
+    }
+
+    public boolean isShard() {
+        return (flags & IS_SHARD) != 0;
+    }
+
+    /**
+     * @param filter The filter for the bucket that resulted in this context/domain.  Can be null if this is the root context.
+     * @param domain The resulting set of documents for this facet.
+     */
+    public FacetContext sub(Query filter, DocSet domain) {
+        FacetContext ctx = new FacetContext();
+        ctx.parent = this;
+        ctx.base = domain;
+        ctx.filter = filter;
+
+        // carry over from parent
+        ctx.flags = flags;
+        ctx.qcontext = qcontext;
+        ctx.req = req;
+        ctx.searcher = searcher;
+
+        return ctx;
+    }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessor.java
@@ -42,10 +42,10 @@ import static org.apache.solr.search.facet.FacetContext.SKIP_FACET;
  * Facet processing based on field values. (not range nor by query)
  * @see FacetField
  */
-abstract class FacetFieldProcessor extends FacetProcessor<FacetField> {
+public abstract class FacetFieldProcessor extends FacetProcessor<FacetField> {
   SchemaField sf;
   SlotAcc indexOrderAcc;
-  int effectiveMincount;
+  public int effectiveMincount;
 
   Map<String,AggValueSource> deferredAggs;  // null if none
 
@@ -55,11 +55,11 @@ abstract class FacetFieldProcessor extends FacetProcessor<FacetField> {
   // For sort="x desc", collectAcc would point to "x", and sortAcc would also point to "x".
   // collectAcc would be used to accumulate all buckets, and sortAcc would be used to sort those buckets.
   //
-  SlotAcc collectAcc;  // Accumulator to collect across entire domain (in addition to the countAcc).  May be null.
+  public SlotAcc collectAcc;  // Accumulator to collect across entire domain (in addition to the countAcc).  May be null.
   SlotAcc sortAcc;     // Accumulator to use for sorting *only* (i.e. not used for collection). May be an alias of countAcc, collectAcc, or indexOrderAcc
   SlotAcc[] otherAccs; // Accumulators that do not need to be calculated across all buckets.
 
-  SpecialSlotAcc allBucketsAcc;  // this can internally refer to otherAccs and/or collectAcc. setNextReader should be called on otherAccs directly if they exist.
+  public SpecialSlotAcc allBucketsAcc;  // this can internally refer to otherAccs and/or collectAcc. setNextReader should be called on otherAccs directly if they exist.
 
   FacetFieldProcessor(FacetContext fcontext, FacetField freq, SchemaField sf) {
     super(fcontext, freq);
@@ -438,14 +438,14 @@ abstract class FacetFieldProcessor extends FacetProcessor<FacetField> {
     }
   }
 
-  static class SpecialSlotAcc extends SlotAcc {
+  public static class SpecialSlotAcc extends SlotAcc {
     SlotAcc collectAcc;
     SlotAcc[] otherAccs;
     int collectAccSlot;
     int otherAccsSlot;
     long count;
 
-    SpecialSlotAcc(FacetContext fcontext, SlotAcc collectAcc, int collectAccSlot, SlotAcc[] otherAccs, int otherAccsSlot) {
+    public SpecialSlotAcc(FacetContext fcontext, SlotAcc collectAcc, int collectAccSlot, SlotAcc[] otherAccs, int otherAccsSlot) {
       super(fcontext);
       this.collectAcc = collectAcc;
       this.collectAccSlot = collectAccSlot;

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArray.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArray.java
@@ -33,9 +33,9 @@ import static org.apache.solr.search.facet.FacetContext.SKIP_FACET;
  */
 abstract class FacetFieldProcessorByArray extends FacetFieldProcessor {
   BytesRefBuilder prefixRef;
-  int startTermIndex;
-  int endTermIndex;
-  int nTerms;
+  public int startTermIndex;
+  public int endTermIndex;
+  public int nTerms;
   int nDocs;
   int maxSlots;
 

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArrayUIF.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArrayUIF.java
@@ -26,11 +26,11 @@ import org.apache.solr.schema.SchemaField;
 
 /** {@link UnInvertedField} implementation of field faceting.
  * It's a top-level term cache. */
-class FacetFieldProcessorByArrayUIF extends FacetFieldProcessorByArray {
+public class FacetFieldProcessorByArrayUIF extends FacetFieldProcessorByArray {
   UnInvertedField uif;
   TermsEnum te;
 
-  FacetFieldProcessorByArrayUIF(FacetContext fcontext, FacetField freq, SchemaField sf) {
+  public FacetFieldProcessorByArrayUIF(FacetContext fcontext, FacetField freq, SchemaField sf) {
     super(fcontext, freq, sf);
   }
 

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
@@ -328,23 +328,6 @@ public class FacetModule extends SearchComponent {
 }
 
 
-// TODO: perhaps factor out some sort of root/parent facet object that doesn't depend
-// on stuff like ResponseBuilder, but contains request parameters,
-// root filter lists (for filter exclusions), etc?
-class FacetComponentState {
-  ResponseBuilder rb;
-  Map<String,Object> facetCommands;
-  FacetRequest facetRequest;
-  boolean isShard;
-  Map<String,Object> facetInfo; // _facet_ param: contains out-of-band facet info, mainly for refinement requests
-
-  //
-  // Only used for distributed search
-  //
-  FacetMerger merger;
-  FacetMerger.Context mcontext;
-}
-
 // base class for facet functions that can be used in a sort
 abstract class FacetSortableMerger extends FacetMerger {
   public void prepareSort() {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetProcessor.java
@@ -52,7 +52,7 @@ public abstract class FacetProcessor<FacetRequestT extends FacetRequest>  {
   DocSet filter;  // additional filters specified by "filter"  // TODO: do these need to be on the context to support recomputing during multi-select?
   LinkedHashMap<String,SlotAcc> accMap;
   SlotAcc[] accs;
-  CountSlotAcc countAcc;
+  public CountSlotAcc countAcc;
 
   /** factory method for invoking json facet framework as whole.
    * Note: this is currently only used from SimpleFacets, not from JSON Facet API itself. */

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
@@ -236,55 +236,6 @@ public abstract class FacetRequest {
 }
 
 
-class FacetContext {
-  // Context info for actually executing a local facet command
-  public static final int IS_SHARD=0x01;
-  public static final int IS_REFINEMENT=0x02;
-  public static final int SKIP_FACET=0x04;  // refinement: skip calculating this immediate facet, but proceed to specific sub-facets based on facetInfo
-
-  Map<String,Object> facetInfo; // refinement info for this node
-  QueryContext qcontext;
-  SolrQueryRequest req;  // TODO: replace with params?
-  SolrIndexSearcher searcher;
-  Query filter;  // TODO: keep track of as a DocSet or as a Query?
-  DocSet base;
-  FacetContext parent;
-  int flags;
-  FacetDebugInfo debugInfo;
-  
-  public void setDebugInfo(FacetDebugInfo debugInfo) {
-    this.debugInfo = debugInfo;
-  }
-  
-  public FacetDebugInfo getDebugInfo() {
-    return debugInfo;
-  }
-  
-  public boolean isShard() {
-    return (flags & IS_SHARD) != 0;
-  }
-
-  /**
-   * @param filter The filter for the bucket that resulted in this context/domain.  Can be null if this is the root context.
-   * @param domain The resulting set of documents for this facet.
-   */
-  public FacetContext sub(Query filter, DocSet domain) {
-    FacetContext ctx = new FacetContext();
-    ctx.parent = this;
-    ctx.base = domain;
-    ctx.filter = filter;
-
-    // carry over from parent
-    ctx.flags = flags;
-    ctx.qcontext = qcontext;
-    ctx.req = req;
-    ctx.searcher = searcher;
-
-    return ctx;
-  }
-}
-
-
 abstract class FacetParser<FacetRequestT extends FacetRequest> {
   protected FacetRequestT facet;
   protected FacetParser parent;
@@ -586,32 +537,6 @@ abstract class FacetParser<FacetRequestT extends FacetRequest> {
 
 }
 
-
-class FacetTopParser extends FacetParser<FacetQuery> {
-  private SolrQueryRequest req;
-
-  public FacetTopParser(SolrQueryRequest req) {
-    super(null, "facet");
-    this.facet = new FacetQuery();
-    this.req = req;
-  }
-
-  @Override
-  public FacetQuery parse(Object args) throws SyntaxError {
-    parseSubs(args);
-    return facet;
-  }
-
-  @Override
-  public SolrQueryRequest getSolrRequest() {
-    return req;
-  }
-
-  @Override
-  public IndexSchema getSchema() {
-    return req.getSchema();
-  }
-}
 
 class FacetQueryParser extends FacetParser<FacetQuery> {
   public FacetQueryParser(FacetParser parent, String key) {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetTopParser.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetTopParser.java
@@ -1,0 +1,31 @@
+package org.apache.solr.search.facet;
+
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.search.SyntaxError;
+
+public class FacetTopParser extends FacetParser<FacetQuery> {
+    private SolrQueryRequest req;
+
+    public FacetTopParser(SolrQueryRequest req) {
+        super(null, "facet");
+        this.facet = new FacetQuery();
+        this.req = req;
+    }
+
+    @Override
+    public FacetQuery parse(Object args) throws SyntaxError {
+        parseSubs(args);
+        return facet;
+    }
+
+    @Override
+    public SolrQueryRequest getSolrRequest() {
+        return req;
+    }
+
+    @Override
+    public IndexSchema getSchema() {
+        return req.getSchema();
+    }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/LegacyFacet.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/LegacyFacet.java
@@ -59,7 +59,7 @@ public class LegacyFacet {
   }
 
 
-  Map<String,Object> getLegacy() {
+  public Map<String,Object> getLegacy() {
     subFacets = parseSubFacets(params);
     String[] queries = params.getParams(FacetParams.FACET_QUERY);
     if (queries != null) {

--- a/solr/core/src/java/org/apache/solr/search/facet/SlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SlotAcc.java
@@ -39,7 +39,7 @@ import java.util.List;
  * Sometimes there doesn't need to be a slot distinction, in which case there is just one nominal slot.
  */
 public abstract class SlotAcc implements Closeable {
-  String key; // todo...
+  public String key; // todo...
   protected final FacetContext fcontext;
 
   public SlotAcc(FacetContext fcontext) {
@@ -497,91 +497,3 @@ class StddevSlotAcc extends DoubleFuncSlotAcc {
   }
 }
 
-abstract class CountSlotAcc extends SlotAcc {
-  public CountSlotAcc(FacetContext fcontext) {
-    super(fcontext);
-  }
-
-  public abstract void incrementCount(int slot, int count);
-
-  public abstract int getCount(int slot);
-}
-
-class CountSlotArrAcc extends CountSlotAcc {
-  int[] result;
-
-  public CountSlotArrAcc(FacetContext fcontext, int numSlots) {
-    super(fcontext);
-    result = new int[numSlots];
-  }
-
-  @Override
-  public void collect(int doc, int slotNum) { // TODO: count arrays can use fewer bytes based on the number of docs in
-                                              // the base set (that's the upper bound for single valued) - look at ttf?
-    result[slotNum]++;
-  }
-
-  @Override
-  public int compare(int slotA, int slotB) {
-    return Integer.compare(result[slotA], result[slotB]);
-  }
-
-  @Override
-  public Object getValue(int slotNum) throws IOException {
-    return result[slotNum];
-  }
-
-  public void incrementCount(int slot, int count) {
-    result[slot] += count;
-  }
-
-  public int getCount(int slot) {
-    return result[slot];
-  }
-
-  // internal and expert
-  int[] getCountArray() {
-    return result;
-  }
-
-  @Override
-  public void reset() {
-    Arrays.fill(result, 0);
-  }
-
-  @Override
-  public void resize(Resizer resizer) {
-    resizer.resize(result, 0);
-  }
-}
-
-class SortSlotAcc extends SlotAcc {
-  public SortSlotAcc(FacetContext fcontext) {
-    super(fcontext);
-  }
-
-  @Override
-  public void collect(int doc, int slot) throws IOException {
-    // no-op
-  }
-
-  public int compare(int slotA, int slotB) {
-    return slotA - slotB;
-  }
-
-  @Override
-  public Object getValue(int slotNum) {
-    return slotNum;
-  }
-
-  @Override
-  public void reset() {
-    // no-op
-  }
-
-  @Override
-  public void resize(Resizer resizer) {
-    // sort slot only works with direct-mapped accumulators
-    throw new UnsupportedOperationException();
-  }
-}

--- a/solr/core/src/java/org/apache/solr/search/facet/SortSlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SortSlotAcc.java
@@ -1,0 +1,34 @@
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+
+public class SortSlotAcc extends SlotAcc {
+    public SortSlotAcc(FacetContext fcontext) {
+        super(fcontext);
+    }
+
+    @Override
+    public void collect(int doc, int slot) throws IOException {
+        // no-op
+    }
+
+    public int compare(int slotA, int slotB) {
+        return slotA - slotB;
+    }
+
+    @Override
+    public Object getValue(int slotNum) {
+        return slotNum;
+    }
+
+    @Override
+    public void reset() {
+        // no-op
+    }
+
+    @Override
+    public void resize(Resizer resizer) {
+        // sort slot only works with direct-mapped accumulators
+        throw new UnsupportedOperationException();
+    }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/UnInvertedField.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UnInvertedField.java
@@ -521,7 +521,7 @@ public class UnInvertedField extends DocTermOrds {
   }
 
   /** may return a reused BytesRef */
-  BytesRef getTermValue(TermsEnum te, int termNum) throws IOException {
+  public BytesRef getTermValue(TermsEnum te, int termNum) throws IOException {
     //System.out.println("getTermValue termNum=" + termNum + " this=" + this + " numTerms=" + numTermsInField);
     if (bigTerms.size() > 0) {
       // see if the term is one of our big terms.


### PR DESCRIPTION
Make necessary classes and properties of classes to have public access to optimize facets calculation.  As these classes cant be overridded to support [PLAT-595]

[PLAT-595]: https://unbxddev.atlassian.net/browse/PLAT-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ